### PR TITLE
feat(chat): private conversations — models, APIs, visibility, formatters, archive/unarchive

### DIFF
--- a/prisma/migrations/20250904153059_add_private_conversations/migration.sql
+++ b/prisma/migrations/20250904153059_add_private_conversations/migration.sql
@@ -1,0 +1,100 @@
+-- CreateEnum
+CREATE TYPE "public"."ContentType" AS ENUM ('TEXT', 'IMAGE');
+
+-- CreateEnum
+CREATE TYPE "public"."ReactionType" AS ENUM ('LIKE', 'LOVE', 'ADMIRE');
+
+-- CreateTable
+CREATE TABLE "public"."PrivateConversation" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "archivedAt" TIMESTAMP(3),
+    "lastMessageId" TEXT,
+    "lastMessageAt" TIMESTAMP(3),
+
+    CONSTRAINT "PrivateConversation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."PrivateConversationParticipant" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "unreadCount" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "PrivateConversationParticipant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."PrivateMessage" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "senderId" TEXT,
+    "content" TEXT,
+    "contentType" "public"."ContentType" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "readAt" TIMESTAMP(3),
+    "deletedAt" TIMESTAMP(3),
+    "reactionType" "public"."ReactionType",
+    "reactedById" TEXT,
+
+    CONSTRAINT "PrivateMessage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."PrivateMessageAttachment" (
+    "id" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "mimeType" TEXT,
+    "size" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PrivateMessageAttachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PrivateConversation_lastMessageId_key" ON "public"."PrivateConversation"("lastMessageId");
+
+-- CreateIndex
+CREATE INDEX "PrivateConversation_updatedAt_idx" ON "public"."PrivateConversation"("updatedAt");
+
+-- CreateIndex
+CREATE INDEX "PrivateConversation_lastMessageAt_idx" ON "public"."PrivateConversation"("lastMessageAt");
+
+-- CreateIndex
+CREATE INDEX "PrivateConversationParticipant_accountId_idx" ON "public"."PrivateConversationParticipant"("accountId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PrivateConversationParticipant_conversationId_accountId_key" ON "public"."PrivateConversationParticipant"("conversationId", "accountId");
+
+-- CreateIndex
+CREATE INDEX "PrivateMessage_conversationId_createdAt_idx" ON "public"."PrivateMessage"("conversationId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "PrivateMessage_senderId_createdAt_idx" ON "public"."PrivateMessage"("senderId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "PrivateMessageAttachment_messageId_idx" ON "public"."PrivateMessageAttachment"("messageId");
+
+-- AddForeignKey
+ALTER TABLE "public"."PrivateConversation" ADD CONSTRAINT "PrivateConversation_lastMessageId_fkey" FOREIGN KEY ("lastMessageId") REFERENCES "public"."PrivateMessage"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PrivateConversationParticipant" ADD CONSTRAINT "PrivateConversationParticipant_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "public"."PrivateConversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PrivateConversationParticipant" ADD CONSTRAINT "PrivateConversationParticipant_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "public"."Account"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PrivateMessage" ADD CONSTRAINT "PrivateMessage_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "public"."PrivateConversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PrivateMessage" ADD CONSTRAINT "PrivateMessage_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "public"."Account"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PrivateMessage" ADD CONSTRAINT "PrivateMessage_reactedById_fkey" FOREIGN KEY ("reactedById") REFERENCES "public"."Account"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PrivateMessageAttachment" ADD CONSTRAINT "PrivateMessageAttachment_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "public"."PrivateMessage"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250904155717_remove_lastmessage_field/migration.sql
+++ b/prisma/migrations/20250904155717_remove_lastmessage_field/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `lastMessageAt` on the `PrivateConversation` table. All the data in the column will be lost.
+  - You are about to drop the column `lastMessageId` on the `PrivateConversation` table. All the data in the column will be lost.
+  - You are about to drop the column `size` on the `PrivateMessageAttachment` table. All the data in the column will be lost.
+  - Made the column `senderId` on table `PrivateMessage` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `content` on table `PrivateMessage` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."PrivateConversation" DROP CONSTRAINT "PrivateConversation_lastMessageId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."PrivateMessage" DROP CONSTRAINT "PrivateMessage_senderId_fkey";
+
+-- DropIndex
+DROP INDEX "public"."PrivateConversation_lastMessageAt_idx";
+
+-- DropIndex
+DROP INDEX "public"."PrivateConversation_lastMessageId_key";
+
+-- AlterTable
+ALTER TABLE "public"."PrivateConversation" DROP COLUMN "lastMessageAt",
+DROP COLUMN "lastMessageId";
+
+-- AlterTable
+ALTER TABLE "public"."PrivateMessage" ALTER COLUMN "senderId" SET NOT NULL,
+ALTER COLUMN "content" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."PrivateMessageAttachment" DROP COLUMN "size";
+
+-- AddForeignKey
+ALTER TABLE "public"."PrivateMessage" ADD CONSTRAINT "PrivateMessage_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "public"."Account"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250904160137_add_timestamps_to_models/migration.sql
+++ b/prisma/migrations/20250904160137_add_timestamps_to_models/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - Added the required column `updatedAt` to the `PrivateConversationParticipant` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `PrivateMessage` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `PrivateMessageAttachment` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."PrivateConversationParticipant" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."PrivateMessage" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."PrivateMessageAttachment" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;

--- a/prisma/migrations/20250904165830_add_private_message_visibility/migration.sql
+++ b/prisma/migrations/20250904165830_add_private_message_visibility/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "public"."PrivateMessageVisibility" (
+    "id" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "readAt" TIMESTAMP(3),
+    "deletedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PrivateMessageVisibility_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PrivateMessageVisibility_accountId_idx" ON "public"."PrivateMessageVisibility"("accountId");
+
+-- CreateIndex
+CREATE INDEX "PrivateMessageVisibility_messageId_idx" ON "public"."PrivateMessageVisibility"("messageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PrivateMessageVisibility_messageId_accountId_key" ON "public"."PrivateMessageVisibility"("messageId", "accountId");
+
+-- AddForeignKey
+ALTER TABLE "public"."PrivateMessageVisibility" ADD CONSTRAINT "PrivateMessageVisibility_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "public"."PrivateMessage"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PrivateMessageVisibility" ADD CONSTRAINT "PrivateMessageVisibility_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "public"."Account"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -111,6 +111,7 @@ model Account {
   ConversationParticipant    PrivateConversationParticipant[]
   sentPrivateMessages        PrivateMessage[]                 @relation("SentMessages")
   reactedMessages            PrivateMessage[]                 @relation("ReactedMessages")
+  privateMessageVisibilities PrivateMessageVisibility[]
 
   @@unique([provider, providerId])
   @@index([status])
@@ -207,6 +208,7 @@ model PrivateMessage {
   reactionType   ReactionType?
   reactedById    String?
   reactedBy      Account?                   @relation("ReactedMessages", fields: [reactedById], references: [id], onDelete: SetNull)
+  visibilities   PrivateMessageVisibility[]
 
   @@index([conversationId, createdAt])
   @@index([senderId, createdAt])
@@ -221,5 +223,21 @@ model PrivateMessageAttachment {
   createdAt DateTime       @default(now())
   updatedAt DateTime       @updatedAt
 
+  @@index([messageId])
+}
+
+model PrivateMessageVisibility {
+  id        String         @id @default(uuid())
+  message   PrivateMessage @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  messageId String
+  account   Account        @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  accountId String
+  readAt    DateTime?
+  deletedAt DateTime?
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
+
+  @@unique([messageId, accountId])
+  @@index([accountId])
   @@index([messageId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -184,6 +184,8 @@ model PrivateConversationParticipant {
   account        Account             @relation(fields: [accountId], references: [id], onDelete: Cascade)
   accountId      String
   unreadCount    Int                 @default(0)
+  createdAt      DateTime            @default(now())
+  updatedAt      DateTime            @updatedAt
 
   @@unique([conversationId, accountId])
   @@index([accountId])
@@ -198,6 +200,7 @@ model PrivateMessage {
   content        String
   contentType    ContentType
   createdAt      DateTime                   @default(now())
+  updatedAt      DateTime                   @updatedAt
   readAt         DateTime?
   deletedAt      DateTime?
   attachments    PrivateMessageAttachment[]
@@ -216,6 +219,7 @@ model PrivateMessageAttachment {
   url       String
   mimeType  String?
   createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
 
   @@index([messageId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,24 +79,38 @@ enum Gender {
   FEMALE
 }
 
+enum ContentType {
+  TEXT
+  IMAGE
+}
+
+enum ReactionType {
+  LIKE
+  LOVE
+  ADMIRE
+}
+
 model Account {
-  id                         String         @id @default(uuid())
+  id                         String                           @id @default(uuid())
   name                       String
-  email                      String         @unique
+  email                      String                           @unique
   password                   String
-  role                       Role           @default(USER)
-  createdAt                  DateTime       @default(now())
-  updatedAt                  DateTime       @updatedAt
-  status                     Status         @default(UNVERIFIED)
+  role                       Role                             @default(USER)
+  createdAt                  DateTime                         @default(now())
+  updatedAt                  DateTime                         @updatedAt
+  status                     Status                           @default(UNVERIFIED)
   verificationCode           String?
   verificationCodeExpiresAt  DateTime?
   passwordResetCode          String?
   passwordResetCodeExpiresAt DateTime?
   refreshTokens              RefreshToken[]
-  provider                   Provider       @default(LOCAL)
+  provider                   Provider                         @default(LOCAL)
   providerId                 String?
   user                       User?
   brand                      Brand?
+  ConversationParticipant    PrivateConversationParticipant[]
+  sentMessages               PrivateMessage[]                 @relation("SentMessages")
+  reactedMessages            PrivateMessage[]                 @relation("ReactedMessages")
 
   @@unique([provider, providerId])
   @@index([status])
@@ -150,4 +164,64 @@ model RefreshToken {
   jti           String         @unique
 
   @@index([expiresAt])
+}
+
+model PrivateConversation {
+  id            String                           @id @default(uuid())
+  createdAt     DateTime                         @default(now())
+  updatedAt     DateTime                         @updatedAt
+  archivedAt    DateTime?
+  lastMessageId String?                          @unique
+  lastMessage   PrivateMessage?                  @relation("ConversationLastMessage", fields: [lastMessageId], references: [id], onDelete: SetNull)
+  lastMessageAt DateTime?
+  participants  PrivateConversationParticipant[]
+  messages      PrivateMessage[]
+
+  @@index([updatedAt])
+  @@index([lastMessageAt])
+}
+
+model PrivateConversationParticipant {
+  id             String              @id @default(uuid())
+  conversation   PrivateConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  conversationId String
+  account        Account             @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  accountId      String
+  unreadCount    Int                 @default(0)
+
+  @@unique([conversationId, accountId])
+  @@index([accountId])
+}
+
+model PrivateMessage {
+  id                  String                     @id @default(uuid())
+  conversation        PrivateConversation        @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  conversationId      String
+  sender              Account?                   @relation("SentMessages", fields: [senderId], references: [id], onDelete: SetNull)
+  senderId            String?
+  content             String?
+  contentType         ContentType
+  createdAt           DateTime                   @default(now())
+  readAt              DateTime?
+  deletedAt           DateTime?
+  attachments         PrivateMessageAttachment[]
+  reactionType        ReactionType?
+  reactedById         String?
+  reactedBy           Account?                   @relation("ReactedMessages", fields: [reactedById], references: [id], onDelete: SetNull)
+  lastForConversation PrivateConversation?       @relation("ConversationLastMessage")
+
+  @@index([conversationId, createdAt])
+  @@index([senderId, createdAt])
+}
+
+model PrivateMessageAttachment {
+  id        String         @id @default(uuid())
+  message   PrivateMessage @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  messageId String
+  url       String
+  mimeType  String?
+  size      Int?
+  createdAt DateTime       @default(now())
+
+  @@index([messageId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -109,7 +109,7 @@ model Account {
   user                       User?
   brand                      Brand?
   ConversationParticipant    PrivateConversationParticipant[]
-  sentMessages               PrivateMessage[]                 @relation("SentMessages")
+  sentPrivateMessages        PrivateMessage[]                 @relation("SentMessages")
   reactedMessages            PrivateMessage[]                 @relation("ReactedMessages")
 
   @@unique([provider, providerId])
@@ -167,18 +167,14 @@ model RefreshToken {
 }
 
 model PrivateConversation {
-  id            String                           @id @default(uuid())
-  createdAt     DateTime                         @default(now())
-  updatedAt     DateTime                         @updatedAt
-  archivedAt    DateTime?
-  lastMessageId String?                          @unique
-  lastMessage   PrivateMessage?                  @relation("ConversationLastMessage", fields: [lastMessageId], references: [id], onDelete: SetNull)
-  lastMessageAt DateTime?
-  participants  PrivateConversationParticipant[]
-  messages      PrivateMessage[]
+  id           String                           @id @default(uuid())
+  createdAt    DateTime                         @default(now())
+  updatedAt    DateTime                         @updatedAt
+  archivedAt   DateTime?
+  participants PrivateConversationParticipant[]
+  messages     PrivateMessage[]
 
   @@index([updatedAt])
-  @@index([lastMessageAt])
 }
 
 model PrivateConversationParticipant {
@@ -194,21 +190,20 @@ model PrivateConversationParticipant {
 }
 
 model PrivateMessage {
-  id                  String                     @id @default(uuid())
-  conversation        PrivateConversation        @relation(fields: [conversationId], references: [id], onDelete: Cascade)
-  conversationId      String
-  sender              Account?                   @relation("SentMessages", fields: [senderId], references: [id], onDelete: SetNull)
-  senderId            String?
-  content             String?
-  contentType         ContentType
-  createdAt           DateTime                   @default(now())
-  readAt              DateTime?
-  deletedAt           DateTime?
-  attachments         PrivateMessageAttachment[]
-  reactionType        ReactionType?
-  reactedById         String?
-  reactedBy           Account?                   @relation("ReactedMessages", fields: [reactedById], references: [id], onDelete: SetNull)
-  lastForConversation PrivateConversation?       @relation("ConversationLastMessage")
+  id             String                     @id @default(uuid())
+  conversation   PrivateConversation        @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  conversationId String
+  sender         Account                    @relation("SentMessages", fields: [senderId], references: [id], onDelete: Cascade)
+  senderId       String
+  content        String
+  contentType    ContentType
+  createdAt      DateTime                   @default(now())
+  readAt         DateTime?
+  deletedAt      DateTime?
+  attachments    PrivateMessageAttachment[]
+  reactionType   ReactionType?
+  reactedById    String?
+  reactedBy      Account?                   @relation("ReactedMessages", fields: [reactedById], references: [id], onDelete: SetNull)
 
   @@index([conversationId, createdAt])
   @@index([senderId, createdAt])
@@ -220,7 +215,6 @@ model PrivateMessageAttachment {
   messageId String
   url       String
   mimeType  String?
-  size      Int?
   createdAt DateTime       @default(now())
 
   @@index([messageId])

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ const cookieParser = require("cookie-parser");
 import authRouter from "./modules/auth/auth.routes";
 import userRouter from "./modules/user/user.routes";
 import brandRouter from "./modules/brand/brand.routes";
+import chatRouter from "./modules/chat/chat.routes";
 import { notFound } from "./middlewares/notFound.middleware";
 import { errorHandler } from "./middlewares/error.middleware";
 import { cleanResponseMiddleware } from "./middlewares/cleanResponse.middleware";
@@ -20,6 +21,7 @@ app.use(cleanResponseMiddleware());
 app.use("/api/v1/auth", authRouter);
 app.use("/api/v1/users", userRouter);
 app.use("/api/v1/brands", brandRouter);
+app.use("/api/v1/chats", chatRouter);
 
 // 404 catcher — should come after routes
 app.use(notFound);

--- a/src/modules/auth/auth.select.ts
+++ b/src/modules/auth/auth.select.ts
@@ -29,3 +29,13 @@ export const profileSelect = {
   user: false,
   brand: false,
 };
+
+export const chatParticipantSelect = {
+  select: {
+    id: true,
+    name: true,
+    email: true,
+    brand: { select: { logo: true } },
+    user: { select: { photo: true } },
+  },
+};

--- a/src/modules/chat/chat.routes.ts
+++ b/src/modules/chat/chat.routes.ts
@@ -1,0 +1,9 @@
+import express from "express";
+
+import privateRouter from "./privateChat/private.routes";
+
+const router = express.Router();
+
+router.use("/private", privateRouter);
+
+export default router;

--- a/src/modules/chat/privateChat/conversation/conversation.controller.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.controller.ts
@@ -16,13 +16,14 @@ export const getOrCreatePrivateConversation: RequestHandler = async (
     recipientId: req.params.recipientId,
     userId: req.account?.id!,
   };
-  const conversation = await privateConverstionService.getOrCreateConversation(
-    payload
-  );
+  const { conversation, isNew } =
+    await privateConverstionService.getOrCreateConversation(payload);
 
   sendResponse(res, {
-    statusCode: HttpStatus.Created,
-    message: "Private conversation created successfully.",
+    statusCode: isNew ? HttpStatus.Created : HttpStatus.OK,
+    message: isNew
+      ? "Private conversation created successfully."
+      : "Private conversation retrieved successfully.",
     data: {
       conversation,
     },

--- a/src/modules/chat/privateChat/conversation/conversation.controller.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.controller.ts
@@ -1,0 +1,27 @@
+import { RequestHandler } from "express";
+
+import { IGetOrCreatePrivateConversation } from "./conversation.interface";
+import privateConverstionService from "./conversation.service";
+import { sendResponse } from "../../../../utils/response";
+import { HttpStatus } from "../../../../enums/httpStatus.enum";
+
+export const getOrCreatePrivateConversation: RequestHandler = async (
+  req,
+  res
+) => {
+  const payload: IGetOrCreatePrivateConversation = {
+    recipientId: req.params.recipientId,
+    userId: req.account?.id!,
+  };
+  const conversation = await privateConverstionService.getOrCreateConversation(
+    payload
+  );
+
+  sendResponse(res, {
+    statusCode: HttpStatus.Created,
+    message: "Private conversation created successfully.",
+    data: {
+      conversation,
+    },
+  });
+};

--- a/src/modules/chat/privateChat/conversation/conversation.controller.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.controller.ts
@@ -1,9 +1,9 @@
 import { RequestHandler } from "express";
 
 import {
-  IGetOrCreatePrivateConversation,
-  IGetPrivateConversation,
-  IGetAllPrivateConversations,
+  IGetOrCreatePrivateConversationPayload,
+  IGetPrivateConversationPayload,
+  IGetAllPrivateConversationsPayload,
 } from "./conversation.interface";
 import privateConverstionService from "./conversation.service";
 import { sendResponse } from "../../../../utils/response";
@@ -13,7 +13,7 @@ export const getOrCreatePrivateConversation: RequestHandler = async (
   req,
   res
 ) => {
-  const payload: IGetOrCreatePrivateConversation = {
+  const payload: IGetOrCreatePrivateConversationPayload = {
     recipientId: req.params.recipientId,
     userId: req.account?.id!,
   };
@@ -32,7 +32,7 @@ export const getOrCreatePrivateConversation: RequestHandler = async (
 };
 
 export const getPrivateConversation: RequestHandler = async (req, res) => {
-  const payload: IGetPrivateConversation = {
+  const payload: IGetPrivateConversationPayload = {
     conversationId: req.params.conversationId,
     userId: req.account?.id!,
   };
@@ -48,7 +48,7 @@ export const getPrivateConversation: RequestHandler = async (req, res) => {
 };
 
 export const getAllprivateConversations: RequestHandler = async (req, res) => {
-  const payload: IGetAllPrivateConversations = {
+  const payload: IGetAllPrivateConversationsPayload = {
     userId: req.account?.id!,
   };
   const conversations = await privateConverstionService.getAllConversations(

--- a/src/modules/chat/privateChat/conversation/conversation.controller.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.controller.ts
@@ -5,6 +5,7 @@ import {
   IGetPrivateConversationPayload,
   IGetAllPrivateConversationsPayload,
   IArchivePrivateConversation,
+  IUnarchivePrivateConversation,
 } from "./conversation.interface";
 import privateConverstionService from "./conversation.service";
 import { sendResponse } from "../../../../utils/response";
@@ -75,6 +76,23 @@ export const archivePrivateConversation: RequestHandler = async (req, res) => {
   sendResponse(res, {
     statusCode: HttpStatus.OK,
     message: "Private conversations archieved successfully.",
+    data,
+  });
+};
+
+export const unarchivePrivateConversation: RequestHandler = async (
+  req,
+  res
+) => {
+  const payload: IUnarchivePrivateConversation = {
+    userId: req.account?.id!,
+    conversationId: req.params.conversationId,
+  };
+  const data = await privateConverstionService.unarchiveConversation(payload);
+
+  sendResponse(res, {
+    statusCode: HttpStatus.OK,
+    message: "Private conversation unarchived successfully.",
     data,
   });
 };

--- a/src/modules/chat/privateChat/conversation/conversation.controller.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.controller.ts
@@ -1,6 +1,9 @@
 import { RequestHandler } from "express";
 
-import { IGetOrCreatePrivateConversation } from "./conversation.interface";
+import {
+  IGetOrCreatePrivateConversation,
+  IGetPrivateConversation,
+} from "./conversation.interface";
 import privateConverstionService from "./conversation.service";
 import { sendResponse } from "../../../../utils/response";
 import { HttpStatus } from "../../../../enums/httpStatus.enum";
@@ -20,6 +23,22 @@ export const getOrCreatePrivateConversation: RequestHandler = async (
   sendResponse(res, {
     statusCode: HttpStatus.Created,
     message: "Private conversation created successfully.",
+    data: {
+      conversation,
+    },
+  });
+};
+
+export const getPrivateConversation: RequestHandler = async (req, res) => {
+  const payload: IGetPrivateConversation = {
+    conversationId: req.params.conversationId,
+    userId: req.account?.id!,
+  };
+  const conversation = await privateConverstionService.getConversation(payload);
+
+  sendResponse(res, {
+    statusCode: HttpStatus.OK,
+    message: "Private conversation retrieved successfully.",
     data: {
       conversation,
     },

--- a/src/modules/chat/privateChat/conversation/conversation.controller.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.controller.ts
@@ -3,6 +3,7 @@ import { RequestHandler } from "express";
 import {
   IGetOrCreatePrivateConversation,
   IGetPrivateConversation,
+  IGetAllPrivateConversations,
 } from "./conversation.interface";
 import privateConverstionService from "./conversation.service";
 import { sendResponse } from "../../../../utils/response";
@@ -42,6 +43,23 @@ export const getPrivateConversation: RequestHandler = async (req, res) => {
     message: "Private conversation retrieved successfully.",
     data: {
       conversation,
+    },
+  });
+};
+
+export const getAllprivateConversations: RequestHandler = async (req, res) => {
+  const payload: IGetAllPrivateConversations = {
+    userId: req.account?.id!,
+  };
+  const conversations = await privateConverstionService.getAllConversations(
+    payload
+  );
+
+  sendResponse(res, {
+    statusCode: HttpStatus.OK,
+    message: "Private conversations retrieved successfully.",
+    data: {
+      conversations,
     },
   });
 };

--- a/src/modules/chat/privateChat/conversation/conversation.controller.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.controller.ts
@@ -17,7 +17,7 @@ export const getOrCreatePrivateConversation: RequestHandler = async (
 ) => {
   const payload: IGetOrCreatePrivateConversationPayload = {
     recipientId: req.params.recipientId,
-    userId: req.account?.id!,
+    accountId: req.account?.id!,
   };
   const { conversation, isNew } =
     await privateConverstionService.getOrCreateConversation(payload);
@@ -36,7 +36,7 @@ export const getOrCreatePrivateConversation: RequestHandler = async (
 export const getPrivateConversation: RequestHandler = async (req, res) => {
   const payload: IGetPrivateConversationPayload = {
     conversationId: req.params.conversationId,
-    userId: req.account?.id!,
+    accountId: req.account?.id!,
   };
   const conversation = await privateConverstionService.getConversation(payload);
 
@@ -51,7 +51,7 @@ export const getPrivateConversation: RequestHandler = async (req, res) => {
 
 export const getAllprivateConversations: RequestHandler = async (req, res) => {
   const payload: IGetAllPrivateConversationsPayload = {
-    userId: req.account?.id!,
+    accountId: req.account?.id!,
   };
   const conversations = await privateConverstionService.getAllConversations(
     payload
@@ -68,7 +68,7 @@ export const getAllprivateConversations: RequestHandler = async (req, res) => {
 
 export const archivePrivateConversation: RequestHandler = async (req, res) => {
   const payload: IArchivePrivateConversation = {
-    userId: req.account?.id!,
+    accountId: req.account?.id!,
     conversationId: req.params.conversationId,
   };
   const data = await privateConverstionService.archiveConversation(payload);
@@ -85,7 +85,7 @@ export const unarchivePrivateConversation: RequestHandler = async (
   res
 ) => {
   const payload: IUnarchivePrivateConversation = {
-    userId: req.account?.id!,
+    accountId: req.account?.id!,
     conversationId: req.params.conversationId,
   };
   const data = await privateConverstionService.unarchiveConversation(payload);

--- a/src/modules/chat/privateChat/conversation/conversation.controller.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.controller.ts
@@ -4,6 +4,7 @@ import {
   IGetOrCreatePrivateConversationPayload,
   IGetPrivateConversationPayload,
   IGetAllPrivateConversationsPayload,
+  IArchivePrivateConversation,
 } from "./conversation.interface";
 import privateConverstionService from "./conversation.service";
 import { sendResponse } from "../../../../utils/response";
@@ -61,5 +62,19 @@ export const getAllprivateConversations: RequestHandler = async (req, res) => {
     data: {
       conversations,
     },
+  });
+};
+
+export const archivePrivateConversation: RequestHandler = async (req, res) => {
+  const payload: IArchivePrivateConversation = {
+    userId: req.account?.id!,
+    conversationId: req.params.conversationId,
+  };
+  const data = await privateConverstionService.archiveConversation(payload);
+
+  sendResponse(res, {
+    statusCode: HttpStatus.OK,
+    message: "Private conversations archieved successfully.",
+    data,
   });
 };

--- a/src/modules/chat/privateChat/conversation/conversation.interface.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.interface.ts
@@ -9,3 +9,8 @@ export interface IPrivateConversation {
   participants: IPrivateConversationParticipant[];
   messages: IPrivateMessage[];
 }
+
+export interface IGetOrCreatePrivateConversation {
+  userId: string;
+  recipientId: string;
+}

--- a/src/modules/chat/privateChat/conversation/conversation.interface.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.interface.ts
@@ -23,3 +23,12 @@ export interface IGetPrivateConversationPayload {
 export interface IGetAllPrivateConversationsPayload {
   userId: string;
 }
+
+export interface IAnyPrivateConversation {
+  id?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+  archivedAt?: Date;
+  participants?: IPrivateConversationParticipant[];
+  messages?: IPrivateMessage[];
+}

--- a/src/modules/chat/privateChat/conversation/conversation.interface.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.interface.ts
@@ -6,6 +6,6 @@ export interface IPrivateConversation {
   createdAt: Date;
   updatedAt: Date;
   archivedAt?: Date;
-  participants: IPrivateConversationParticipant;
-  messages: IPrivateMessage;
+  participants: IPrivateConversationParticipant[];
+  messages: IPrivateMessage[];
 }

--- a/src/modules/chat/privateChat/conversation/conversation.interface.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.interface.ts
@@ -37,3 +37,6 @@ export interface IArchivePrivateConversation {
   userId: string;
   conversationId: string;
 }
+
+export interface IUnarchivePrivateConversation
+  extends IArchivePrivateConversation {}

--- a/src/modules/chat/privateChat/conversation/conversation.interface.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.interface.ts
@@ -19,3 +19,7 @@ export interface IGetPrivateConversation {
   userId: string;
   conversationId: string;
 }
+
+export interface IGetAllPrivateConversations {
+  userId: string;
+}

--- a/src/modules/chat/privateChat/conversation/conversation.interface.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.interface.ts
@@ -1,0 +1,11 @@
+import { IPrivateConversationParticipant } from "../conversationParticipant/conversationParticipant.interface";
+import { IPrivateMessage } from "../message/messge.interface";
+
+export interface IPrivateConversation {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt?: Date;
+  participants: IPrivateConversationParticipant;
+  messages: IPrivateMessage;
+}

--- a/src/modules/chat/privateChat/conversation/conversation.interface.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.interface.ts
@@ -10,16 +10,16 @@ export interface IPrivateConversation {
   messages: IPrivateMessage[];
 }
 
-export interface IGetOrCreatePrivateConversation {
+export interface IGetOrCreatePrivateConversationPayload {
   userId: string;
   recipientId: string;
 }
 
-export interface IGetPrivateConversation {
+export interface IGetPrivateConversationPayload {
   userId: string;
   conversationId: string;
 }
 
-export interface IGetAllPrivateConversations {
+export interface IGetAllPrivateConversationsPayload {
   userId: string;
 }

--- a/src/modules/chat/privateChat/conversation/conversation.interface.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.interface.ts
@@ -32,3 +32,8 @@ export interface IAnyPrivateConversation {
   participants?: IPrivateConversationParticipant[];
   messages?: IPrivateMessage[];
 }
+
+export interface IArchivePrivateConversation {
+  userId: string;
+  conversationId: string;
+}

--- a/src/modules/chat/privateChat/conversation/conversation.interface.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.interface.ts
@@ -11,17 +11,17 @@ export interface IPrivateConversation {
 }
 
 export interface IGetOrCreatePrivateConversationPayload {
-  userId: string;
+  accountId: string;
   recipientId: string;
 }
 
 export interface IGetPrivateConversationPayload {
-  userId: string;
+  accountId: string;
   conversationId: string;
 }
 
 export interface IGetAllPrivateConversationsPayload {
-  userId: string;
+  accountId: string;
 }
 
 export interface IAnyPrivateConversation {
@@ -34,7 +34,7 @@ export interface IAnyPrivateConversation {
 }
 
 export interface IArchivePrivateConversation {
-  userId: string;
+  accountId: string;
   conversationId: string;
 }
 

--- a/src/modules/chat/privateChat/conversation/conversation.interface.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.interface.ts
@@ -14,3 +14,8 @@ export interface IGetOrCreatePrivateConversation {
   userId: string;
   recipientId: string;
 }
+
+export interface IGetPrivateConversation {
+  userId: string;
+  conversationId: string;
+}

--- a/src/modules/chat/privateChat/conversation/conversation.routes.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.routes.ts
@@ -3,11 +3,13 @@ import express from "express";
 import {
   getOrCreatePrivateConversationZodSchema,
   getPrivateConversationZodSchema,
+  archiveConversationZodSchema,
 } from "./conversation.validation";
 import {
   getOrCreatePrivateConversation,
   getPrivateConversation,
   getAllprivateConversations,
+  archivePrivateConversation,
 } from "./conversation.controller";
 import { validate } from "../../../../middlewares/validation.middleware";
 import { authenticate } from "../../../../middlewares/authenticate.middleware";
@@ -29,5 +31,12 @@ router.get(
 );
 
 router.get("/", authenticate, getAllprivateConversations);
+
+router.patch(
+  "/:conversationId/archive",
+  authenticate,
+  validate(archiveConversationZodSchema),
+  archivePrivateConversation
+);
 
 export default router;

--- a/src/modules/chat/privateChat/conversation/conversation.routes.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.routes.ts
@@ -7,6 +7,7 @@ import {
 import {
   getOrCreatePrivateConversation,
   getPrivateConversation,
+  getAllprivateConversations,
 } from "./conversation.controller";
 import { validate } from "../../../../middlewares/validation.middleware";
 import { authenticate } from "../../../../middlewares/authenticate.middleware";
@@ -26,5 +27,7 @@ router.get(
   validate(getPrivateConversationZodSchema),
   getPrivateConversation
 );
+
+router.get("/", authenticate, getAllprivateConversations);
 
 export default router;

--- a/src/modules/chat/privateChat/conversation/conversation.routes.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.routes.ts
@@ -4,12 +4,14 @@ import {
   getOrCreatePrivateConversationZodSchema,
   getPrivateConversationZodSchema,
   archiveConversationZodSchema,
+  unarchiveConversationZodSchema,
 } from "./conversation.validation";
 import {
   getOrCreatePrivateConversation,
   getPrivateConversation,
   getAllprivateConversations,
   archivePrivateConversation,
+  unarchivePrivateConversation,
 } from "./conversation.controller";
 import { validate } from "../../../../middlewares/validation.middleware";
 import { authenticate } from "../../../../middlewares/authenticate.middleware";
@@ -37,6 +39,13 @@ router.patch(
   authenticate,
   validate(archiveConversationZodSchema),
   archivePrivateConversation
+);
+
+router.patch(
+  "/:conversationId/unarchive",
+  authenticate,
+  validate(unarchiveConversationZodSchema),
+  unarchivePrivateConversation
 );
 
 export default router;

--- a/src/modules/chat/privateChat/conversation/conversation.routes.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.routes.ts
@@ -1,0 +1,17 @@
+import express from "express";
+
+import { getOrCreatePrivateConversationZodSchema } from "./conversation.validation";
+import { getOrCreatePrivateConversation } from "./conversation.controller";
+import { validate } from "../../../../middlewares/validation.middleware";
+import { authenticate } from "../../../../middlewares/authenticate.middleware";
+
+const router = express.Router();
+
+router.post(
+  "/:recipientId",
+  authenticate,
+  validate(getOrCreatePrivateConversationZodSchema),
+  getOrCreatePrivateConversation
+);
+
+export default router;

--- a/src/modules/chat/privateChat/conversation/conversation.routes.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.routes.ts
@@ -1,7 +1,13 @@
 import express from "express";
 
-import { getOrCreatePrivateConversationZodSchema } from "./conversation.validation";
-import { getOrCreatePrivateConversation } from "./conversation.controller";
+import {
+  getOrCreatePrivateConversationZodSchema,
+  getPrivateConversationZodSchema,
+} from "./conversation.validation";
+import {
+  getOrCreatePrivateConversation,
+  getPrivateConversation,
+} from "./conversation.controller";
 import { validate } from "../../../../middlewares/validation.middleware";
 import { authenticate } from "../../../../middlewares/authenticate.middleware";
 
@@ -12,6 +18,13 @@ router.post(
   authenticate,
   validate(getOrCreatePrivateConversationZodSchema),
   getOrCreatePrivateConversation
+);
+
+router.get(
+  "/:conversationId",
+  authenticate,
+  validate(getPrivateConversationZodSchema),
+  getPrivateConversation
 );
 
 export default router;

--- a/src/modules/chat/privateChat/conversation/conversation.service.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.service.ts
@@ -1,0 +1,137 @@
+import prisma from "../../../../config/prisma.config";
+import logger from "../../../../config/logger.config";
+import { HttpStatus } from "../../../../enums/httpStatus.enum";
+import APIError from "../../../../utils/APIError";
+import { IGetOrCreatePrivateConversation } from "./conversation.interface";
+import { Status } from "../../../../generated/prisma";
+
+class PrivateConverstionService {
+  /*
+   * Find an existing private conversation between two accounts (userId and recipientId)
+   * that the requesting user can see (no deleted messages), or create one if it doesn't exist.
+   */
+  async getOrCreateConversation(payload: IGetOrCreatePrivateConversation) {
+    const { userId, recipientId } = payload;
+
+    // validate recipient exists
+    const recipient = await prisma.account.findUnique({
+      where: { id: recipientId },
+    });
+    if (!recipient) {
+      throw new APIError("Recipient not found.", HttpStatus.NotFound);
+    }
+
+    // validate recipient active
+    if (recipient.status !== Status.ACTIVE)
+      throw new APIError("Recipient not available.", HttpStatus.BadRequest);
+
+    // Disallow creating a conversation with the same account ID.
+    if (userId === recipientId) {
+      throw new APIError(
+        "Cannot create a conversation with the same account.",
+        HttpStatus.BadRequest
+      );
+    }
+
+    const existing = await prisma.privateConversation.findFirst({
+      where: {
+        AND: [
+          // ensure userId is present as a participant
+          { participants: { some: { accountId: userId } } },
+
+          // ensure recipientId is present as a participant
+          { participants: { some: { accountId: recipientId } } },
+
+          // ensure there are no participants outside the two IDs
+          {
+            participants: {
+              every: { accountId: { in: [userId, recipientId] } },
+            },
+          },
+        ],
+      },
+      include: {
+        // Include participants and their related account data for context.
+        participants: {
+          include: {
+            account: true,
+          },
+        },
+
+        // Include recent messages that are visible to the requesting user.
+        messages: {
+          where: {
+            // Only messages that have a visibility row for this user and
+            // where deletedAt is null (i.e., the user hasn't deleted them).
+            visibilities: {
+              some: {
+                accountId: userId,
+                deletedAt: null,
+              },
+            },
+          },
+          include: {
+            // For each message, include only the visibility row for the requester
+            // to reduce payload size and show read/deleted metadata.
+            visibilities: {
+              where: { accountId: userId },
+              take: 1, // only need the requesting user's visibility
+            },
+
+            // Include any attachments associated with each message.
+            attachments: true,
+
+            // Include a small subset of fields for users who reacted to the message.
+            reactedBy: { select: { id: true, name: true, email: true } },
+          },
+
+          // Order messages newest-first and limit to 50 for a simple page.
+          orderBy: { createdAt: "desc" },
+          take: 50,
+        },
+      },
+    });
+
+    // If we found a conversation return it
+    if (existing) {
+      logger.info("Found existing private conversation", {
+        conversationId: existing.id,
+        participants: existing.participants?.map((p) => p.accountId),
+        messagesCount: existing.messages?.length ?? 0,
+      });
+      return existing; // return the conversation object as-is
+    }
+
+    // No existing conversation was found: create a new conversation with both participants.
+    const conversation = await prisma.privateConversation.create({
+      data: {
+        participants: {
+          create: [
+            {
+              accountId: userId, // create participant row for requesting user
+            },
+            {
+              accountId: recipientId, // create participant row for recipient
+            },
+          ],
+        },
+      },
+      include: {
+        // Return participants with their account info after creation.
+        participants: {
+          include: {
+            account: true,
+          },
+        },
+      },
+    });
+
+    logger.info("Created new private conversation", {
+      conversationId: conversation.id,
+      participants: conversation.participants?.map((p) => p.accountId),
+    });
+    return conversation;
+  }
+}
+
+export default new PrivateConverstionService();

--- a/src/modules/chat/privateChat/conversation/conversation.service.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.service.ts
@@ -8,6 +8,7 @@ import {
   IGetAllPrivateConversations,
 } from "./conversation.interface";
 import { Status } from "../../../../generated/prisma";
+import { chatParticipantSelect } from "../../../auth/auth.select";
 
 class PrivateConverstionService {
   /*
@@ -58,7 +59,7 @@ class PrivateConverstionService {
         // Include participants and their related account data for context.
         participants: {
           include: {
-            account: true,
+            account: chatParticipantSelect,
           },
         },
 
@@ -124,7 +125,7 @@ class PrivateConverstionService {
         // Return participants with their account info after creation.
         participants: {
           include: {
-            account: true,
+            account: chatParticipantSelect,
           },
         },
       },
@@ -150,7 +151,7 @@ class PrivateConverstionService {
         // Include participants and their related account data for context.
         participants: {
           include: {
-            account: true,
+            account: chatParticipantSelect,
           },
         },
 
@@ -215,15 +216,7 @@ class PrivateConverstionService {
         // Include participants and their related account data for context.
         participants: {
           include: {
-            account: {
-              select: {
-                id: true,
-                name: true,
-                email: true,
-                brand: { select: { logo: true } },
-                user: { select: { photo: true } },
-              },
-            },
+            account: chatParticipantSelect,
           },
         },
 

--- a/src/modules/chat/privateChat/conversation/conversation.service.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.service.ts
@@ -2,7 +2,10 @@ import prisma from "../../../../config/prisma.config";
 import logger from "../../../../config/logger.config";
 import { HttpStatus } from "../../../../enums/httpStatus.enum";
 import APIError from "../../../../utils/APIError";
-import { IGetOrCreatePrivateConversation } from "./conversation.interface";
+import {
+  IGetOrCreatePrivateConversation,
+  IGetPrivateConversation,
+} from "./conversation.interface";
 import { Status } from "../../../../generated/prisma";
 
 class PrivateConverstionService {
@@ -129,6 +132,73 @@ class PrivateConverstionService {
     logger.info("Created new private conversation", {
       conversationId: conversation.id,
       participants: conversation.participants?.map((p) => p.accountId),
+    });
+    return conversation;
+  }
+
+  async getConversation(payload: IGetPrivateConversation) {
+    const { userId, conversationId } = payload;
+
+    const conversation = await prisma.privateConversation.findUnique({
+      where: {
+        id: conversationId,
+        // ensure userId is present as a participant
+        participants: { some: { accountId: userId } },
+      },
+      include: {
+        // Include participants and their related account data for context.
+        participants: {
+          include: {
+            account: true,
+          },
+        },
+
+        // Include recent messages that are visible to the requesting user.
+        messages: {
+          where: {
+            // Only messages that have a visibility row for this user and
+            // where deletedAt is null (i.e., the user hasn't deleted them).
+            visibilities: {
+              some: {
+                accountId: userId,
+                deletedAt: null,
+              },
+            },
+          },
+          include: {
+            // For each message, include only the visibility row for the requester
+            // to reduce payload size and show read/deleted metadata.
+            visibilities: {
+              where: { accountId: userId },
+              take: 1, // only need the requesting user's visibility
+            },
+
+            // Include any attachments associated with each message.
+            attachments: true,
+
+            // Include a small subset of fields for users who reacted to the message.
+            reactedBy: { select: { id: true, name: true, email: true } },
+          },
+
+          // Order messages newest-first and limit to 50 for a simple page.
+          orderBy: { createdAt: "desc" },
+          take: 50,
+        },
+      },
+    });
+
+    // Validate that the conversation exists and belongs to the requesting user
+    if (!conversation) {
+      throw new APIError(
+        "You are not authorized to access this conversation or it does not exist",
+        HttpStatus.Forbidden
+      );
+    }
+
+    logger.info("Found private conversation", {
+      conversationId: conversation.id,
+      participants: conversation.participants?.map((p) => p.accountId),
+      messagesCount: conversation.messages?.length ?? 0,
     });
     return conversation;
   }

--- a/src/modules/chat/privateChat/conversation/conversation.service.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.service.ts
@@ -3,9 +3,9 @@ import logger from "../../../../config/logger.config";
 import { HttpStatus } from "../../../../enums/httpStatus.enum";
 import APIError from "../../../../utils/APIError";
 import {
-  IGetOrCreatePrivateConversation,
-  IGetPrivateConversation,
-  IGetAllPrivateConversations,
+  IGetOrCreatePrivateConversationPayload,
+  IGetPrivateConversationPayload,
+  IGetAllPrivateConversationsPayload,
 } from "./conversation.interface";
 import { Status } from "../../../../generated/prisma";
 import { chatParticipantSelect } from "../../../auth/auth.select";
@@ -15,7 +15,9 @@ class PrivateConverstionService {
    * Find an existing private conversation between two accounts (userId and recipientId)
    * that the requesting user can see (no deleted messages), or create one if it doesn't exist.
    */
-  async getOrCreateConversation(payload: IGetOrCreatePrivateConversation) {
+  async getOrCreateConversation(
+    payload: IGetOrCreatePrivateConversationPayload
+  ) {
     const { userId, recipientId } = payload;
 
     // validate recipient exists
@@ -138,7 +140,7 @@ class PrivateConverstionService {
     return { conversation, isNew: true };
   }
 
-  async getConversation(payload: IGetPrivateConversation) {
+  async getConversation(payload: IGetPrivateConversationPayload) {
     const { userId, conversationId } = payload;
 
     const conversation = await prisma.privateConversation.findUnique({
@@ -205,7 +207,7 @@ class PrivateConverstionService {
     return conversation;
   }
 
-  async getAllConversations(payload: IGetAllPrivateConversations) {
+  async getAllConversations(payload: IGetAllPrivateConversationsPayload) {
     const { userId } = payload;
     const conversations = await prisma.privateConversation.findMany({
       where: {

--- a/src/modules/chat/privateChat/conversation/conversation.service.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.service.ts
@@ -146,6 +146,28 @@ class PrivateConverstionService {
       };
     }
 
+    const accounts = await prisma.account.findMany({
+      where: { id: { in: [accountId, recipientId] } },
+    });
+
+    if (accounts.length !== 2) {
+      throw new APIError(
+        "One or both accounts could not be found",
+        HttpStatus.NotFound
+      );
+    }
+
+    const ok: boolean =
+      (accounts[0].role === Role.BRAND && accounts[1].role === Role.USER) ||
+      (accounts[1].role === Role.BRAND && accounts[0].role === Role.USER);
+
+    if (!ok) {
+      throw new APIError(
+        "Invalid participants: conversation requires exactly one brand and one user",
+        HttpStatus.Forbidden
+      );
+    }
+
     // No existing conversation was found: create a new conversation with both participants.
     const conversation = await prisma.privateConversation.create({
       data: {

--- a/src/modules/chat/privateChat/conversation/conversation.service.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.service.ts
@@ -102,7 +102,7 @@ class PrivateConverstionService {
         participants: existing.participants?.map((p) => p.accountId),
         messagesCount: existing.messages?.length ?? 0,
       });
-      return existing; // return the conversation object as-is
+      return { conversation: existing, isNew: false }; // return the conversation object as-is
     }
 
     // No existing conversation was found: create a new conversation with both participants.
@@ -133,7 +133,7 @@ class PrivateConverstionService {
       conversationId: conversation.id,
       participants: conversation.participants?.map((p) => p.accountId),
     });
-    return conversation;
+    return { conversation, isNew: true };
   }
 
   async getConversation(payload: IGetPrivateConversation) {

--- a/src/modules/chat/privateChat/conversation/conversation.validation.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.validation.ts
@@ -9,3 +9,13 @@ export const getOrCreatePrivateConversationZodSchema = z.object({
     })
     .strict(),
 });
+
+export const getPrivateConversationZodSchema = z.object({
+  params: z
+    .object({
+      conversationId: z
+        .string()
+        .uuid({ message: "conversationId must be a valid UUID" }),
+    })
+    .strict(),
+});

--- a/src/modules/chat/privateChat/conversation/conversation.validation.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.validation.ts
@@ -29,3 +29,13 @@ export const archiveConversationZodSchema = z.object({
     })
     .strict(),
 });
+
+export const unarchiveConversationZodSchema = z.object({
+  params: z
+    .object({
+      conversationId: z
+        .string()
+        .uuid({ message: "conversationId must be a valid UUID" }),
+    })
+    .strict(),
+});

--- a/src/modules/chat/privateChat/conversation/conversation.validation.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.validation.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const getOrCreatePrivateConversationZodSchema = z.object({
+  params: z
+    .object({
+      recipientId: z
+        .string()
+        .uuid({ message: "recipientId must be a valid UUID" }),
+    })
+    .strict(),
+});

--- a/src/modules/chat/privateChat/conversation/conversation.validation.ts
+++ b/src/modules/chat/privateChat/conversation/conversation.validation.ts
@@ -19,3 +19,13 @@ export const getPrivateConversationZodSchema = z.object({
     })
     .strict(),
 });
+
+export const archiveConversationZodSchema = z.object({
+  params: z
+    .object({
+      conversationId: z
+        .string()
+        .uuid({ message: "conversationId must be a valid UUID" }),
+    })
+    .strict(),
+});

--- a/src/modules/chat/privateChat/conversationParticipant/conversationParticipant.interface.ts
+++ b/src/modules/chat/privateChat/conversationParticipant/conversationParticipant.interface.ts
@@ -1,0 +1,13 @@
+import { IPrivateConversation } from "../conversation/conversation.interface";
+import { IAccount } from "../../../auth/auth.interface";
+
+export interface IPrivateConversationParticipant {
+  id: string;
+  conversation: IPrivateConversation;
+  conversationId: string;
+  account: IAccount;
+  accountId: string;
+  unreadCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/modules/chat/privateChat/message/messge.interface.ts
+++ b/src/modules/chat/privateChat/message/messge.interface.ts
@@ -2,7 +2,7 @@ import { IPrivateConversation } from "../conversation/conversation.interface";
 import { IAccount } from "../../../auth/auth.interface";
 import { IPrivateMessageAttachment } from "../messageAttachment/messageAttachment.interface";
 import { ContentType, ReactionType } from "../../../../generated/prisma";
-
+import { IPrivateMessageVisibility } from "../messageVisibility/messageVisibility.interface";
 export interface IPrivateMessage {
   id: string;
   conversation: IPrivateConversation;
@@ -15,8 +15,9 @@ export interface IPrivateMessage {
   updatedAt: Date;
   readAt?: Date;
   deletedAt?: Date;
-  attachments: IPrivateMessageAttachment;
+  attachments: IPrivateMessageAttachment[];
   reactionType?: ReactionType;
   reactedById?: string;
   reactedBy?: IAccount;
+  visibilities: IPrivateMessageVisibility[];
 }

--- a/src/modules/chat/privateChat/message/messge.interface.ts
+++ b/src/modules/chat/privateChat/message/messge.interface.ts
@@ -1,0 +1,22 @@
+import { IPrivateConversation } from "../conversation/conversation.interface";
+import { IAccount } from "../../../auth/auth.interface";
+import { IPrivateMessageAttachment } from "../messageAttachment/messageAttachment.interface";
+import { ContentType, ReactionType } from "../../../../generated/prisma";
+
+export interface IPrivateMessage {
+  id: string;
+  conversation: IPrivateConversation;
+  conversationId: string;
+  sender: IAccount;
+  senderId: string;
+  content?: string;
+  contentType: ContentType;
+  createdAt: Date;
+  updatedAt: Date;
+  readAt?: Date;
+  deletedAt?: Date;
+  attachments: IPrivateMessageAttachment;
+  reactionType?: ReactionType;
+  reactedById?: string;
+  reactedBy?: IAccount;
+}

--- a/src/modules/chat/privateChat/messageAttachment/messageAttachment.interface.ts
+++ b/src/modules/chat/privateChat/messageAttachment/messageAttachment.interface.ts
@@ -1,0 +1,11 @@
+import { IPrivateMessage } from "../message/messge.interface";
+
+export interface IPrivateMessageAttachment {
+  id: string;
+  message: IPrivateMessage;
+  messageId: string;
+  url: string;
+  mimeType?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/modules/chat/privateChat/messageVisibility/messageVisibility.interface.ts
+++ b/src/modules/chat/privateChat/messageVisibility/messageVisibility.interface.ts
@@ -1,0 +1,14 @@
+import { IAccount } from "../../../auth/auth.interface";
+import { IPrivateMessage } from "../message/messge.interface";
+
+export interface IPrivateMessageVisibility {
+  id: string;
+  message: IPrivateMessage;
+  messageId: string;
+  account: IAccount;
+  accountId: string;
+  readAt?: Date;
+  deletedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/modules/chat/privateChat/private.routes.ts
+++ b/src/modules/chat/privateChat/private.routes.ts
@@ -1,0 +1,9 @@
+import express from "express";
+
+import conversationRouter from "./conversation/conversation.routes";
+
+const router = express.Router();
+
+router.use("/conversations", conversationRouter);
+
+export default router;


### PR DESCRIPTION
## Summary

This PR delivers full private-conversation support: Prisma models + schema changes, per-user message visibility tracking, conversation formatters, and a complete set of REST endpoints (list, get, get-or-create, archive, unarchive). It also adds types, Zod validation, logging, and refactors (reusable participant select, DTO naming). The two new commits add archive/unarchive endpoints (with validation and access checks).

## What changed (high level)

* **DB / schema**

  * Added models: `PrivateConversation`, `PrivateMessage`, `PrivateConversationParticipant`, `PrivateMessageAttachment`, `PrivateMessageVisibility`.
  
* **New & updated API endpoints**

  * `GET /api/v1/chats/private/conversations` — list all private conversations for the authenticated user (participants + most recent visible message).
  * `GET /api/v1/chats/private/conversations/:conversationId` — fetch a single conversation (participants, latest 50 messages, visibilities, attachments, reactions).
  * `POST(getOrCreate) /api/v1/chats/private/...` — Create a private chat between a user and a brand (no self-chats). If a conversation already exists it’s returned (200 OK); if a new one is created it returns 201 Created.
  * **Archive / Unarchive**

    * `PATCH /api/v1/chats/private/conversations/:conversationId/archive` — archive a conversation for a participant (sets `archivedAt`).
    * `PATCH /api/v1/chats/private/conversations/:conversationId/unarchive` — unarchive (requires `archivedAt` to exist; sets it to `null`).
    * Both routes are protected by authentication and validated by Zod schemas.

* **Services & business logic**

  * `getAllConversations`, `getConversation`, `getOrCreateConversation` implemented/refined.
  * `archiveConversation` and `unarchiveConversation` services verify the requester is a participant and toggle `archivedAt` appropriately (archive sets timestamp if not already archived; unarchive requires an existing `archivedAt` and clears it).
  * `getOrCreateConversation` returns `{ conversation, isNew }` so controllers pick correct status codes.

* **Formatting & utilities**

  * Single and batch conversation formatters:
  * Extracted `chatParticipantSelect` for consistent Prisma selects.

* **Types & validation**

  * Renamed request DTOs to use `Payload` suffix.
  * Added interfaces for `IPrivateMessageVisibility`, participants, messages, attachments.
  * Zod schemas for route param validation (UUID checking), including archive/unarchive schemas.
  * Added runtime checks (e.g., ensure `req.account.id` exists).
  * Added logging around key operations.

## Notable behavior details

* Message fetching in `getConversation` is limited to the **latest 50 messages**, ordered newest-first in the query.
* `getAllConversations` returns the most recent **visible** message per conversation, honoring per-user visibilities and reactions.
* Archive/unarchive operations require participant access. Archive sets `archivedAt` (if not already set); unarchive requires `archivedAt` to be present and clears it.