### PR TITLE
Add Product Management Base APIs 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "postgres": "^3.4.7",
+        "slugify": "^1.6.6",
         "winston": "^3.17.0",
         "zod": "^4.1.5",
         "zod-validation-error": "^4.0.1"
@@ -3393,6 +3394,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "postgres": "^3.4.7",
+    "slugify": "^1.6.6",
     "winston": "^3.17.0",
     "zod": "^4.1.5",
     "zod-validation-error": "^4.0.1"

--- a/prisma/migrations/20250905182918_products_init/migration.sql
+++ b/prisma/migrations/20250905182918_products_init/migration.sql
@@ -1,0 +1,201 @@
+-- CreateEnum
+CREATE TYPE "public"."ProductStatus" AS ENUM ('DRAFT', 'ARCHIVED', 'PUBLISHED');
+
+-- CreateTable
+CREATE TABLE "public"."Product" (
+    "id" TEXT NOT NULL,
+    "brandId" TEXT NOT NULL,
+    "category" "public"."Category" NOT NULL,
+    "title" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "attributes" JSONB,
+    "status" "public"."ProductStatus" NOT NULL DEFAULT 'DRAFT',
+    "material" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Product_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ProductImage" (
+    "id" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "altText" TEXT,
+    "meta" JSONB,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProductImage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ProductOption" (
+    "id" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "label" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "ProductOption_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ProductOptionValue" (
+    "id" TEXT NOT NULL,
+    "productOptionId" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "label" TEXT,
+    "colorHex" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "ProductOptionValue_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."VariantOption" (
+    "id" TEXT NOT NULL,
+    "variantId" TEXT NOT NULL,
+    "productOptionId" TEXT NOT NULL,
+    "productOptionValueId" TEXT NOT NULL,
+
+    CONSTRAINT "VariantOption_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Variant" (
+    "id" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "sku" TEXT NOT NULL,
+    "price" DECIMAL(12,2) NOT NULL,
+    "currency" VARCHAR(3) NOT NULL,
+    "stock" INTEGER NOT NULL DEFAULT 0,
+    "weight" DECIMAL(10,3),
+    "dimensions" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Variant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."VariantImage" (
+    "id" TEXT NOT NULL,
+    "variantId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "altText" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "VariantImage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Tag" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ProductTag" (
+    "productId" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    "pinned" BOOLEAN NOT NULL DEFAULT false,
+    "addedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProductTag_pkey" PRIMARY KEY ("productId","tagId")
+);
+
+-- CreateIndex
+CREATE INDEX "Product_category_status_createdAt_idx" ON "public"."Product"("category", "status", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "Product_material_idx" ON "public"."Product"("material");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Product_brandId_slug_key" ON "public"."Product"("brandId", "slug");
+
+-- CreateIndex
+CREATE INDEX "ProductImage_productId_idx" ON "public"."ProductImage"("productId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProductImage_productId_sortOrder_key" ON "public"."ProductImage"("productId", "sortOrder");
+
+-- CreateIndex
+CREATE INDEX "ProductOption_productId_sortOrder_idx" ON "public"."ProductOption"("productId", "sortOrder");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProductOption_productId_name_key" ON "public"."ProductOption"("productId", "name");
+
+-- CreateIndex
+CREATE INDEX "ProductOptionValue_productOptionId_sortOrder_idx" ON "public"."ProductOptionValue"("productOptionId", "sortOrder");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProductOptionValue_productOptionId_value_key" ON "public"."ProductOptionValue"("productOptionId", "value");
+
+-- CreateIndex
+CREATE INDEX "VariantOption_productOptionValueId_idx" ON "public"."VariantOption"("productOptionValueId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VariantOption_variantId_productOptionId_key" ON "public"."VariantOption"("variantId", "productOptionId");
+
+-- CreateIndex
+CREATE INDEX "Variant_productId_idx" ON "public"."Variant"("productId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Variant_productId_sku_key" ON "public"."Variant"("productId", "sku");
+
+-- CreateIndex
+CREATE INDEX "VariantImage_variantId_idx" ON "public"."VariantImage"("variantId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VariantImage_variantId_sortOrder_key" ON "public"."VariantImage"("variantId", "sortOrder");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_slug_key" ON "public"."Tag"("slug");
+
+-- CreateIndex
+CREATE INDEX "Tag_name_idx" ON "public"."Tag"("name");
+
+-- CreateIndex
+CREATE INDEX "ProductTag_tagId_productId_idx" ON "public"."ProductTag"("tagId", "productId");
+
+-- AddForeignKey
+ALTER TABLE "public"."Product" ADD CONSTRAINT "Product_brandId_fkey" FOREIGN KEY ("brandId") REFERENCES "public"."Brand"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ProductImage" ADD CONSTRAINT "ProductImage_productId_fkey" FOREIGN KEY ("productId") REFERENCES "public"."Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ProductOption" ADD CONSTRAINT "ProductOption_productId_fkey" FOREIGN KEY ("productId") REFERENCES "public"."Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ProductOptionValue" ADD CONSTRAINT "ProductOptionValue_productOptionId_fkey" FOREIGN KEY ("productOptionId") REFERENCES "public"."ProductOption"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."VariantOption" ADD CONSTRAINT "VariantOption_variantId_fkey" FOREIGN KEY ("variantId") REFERENCES "public"."Variant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."VariantOption" ADD CONSTRAINT "VariantOption_productOptionId_fkey" FOREIGN KEY ("productOptionId") REFERENCES "public"."ProductOption"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."VariantOption" ADD CONSTRAINT "VariantOption_productOptionValueId_fkey" FOREIGN KEY ("productOptionValueId") REFERENCES "public"."ProductOptionValue"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Variant" ADD CONSTRAINT "Variant_productId_fkey" FOREIGN KEY ("productId") REFERENCES "public"."Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."VariantImage" ADD CONSTRAINT "VariantImage_variantId_fkey" FOREIGN KEY ("variantId") REFERENCES "public"."Variant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ProductTag" ADD CONSTRAINT "ProductTag_productId_fkey" FOREIGN KEY ("productId") REFERENCES "public"."Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ProductTag" ADD CONSTRAINT "ProductTag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "public"."Tag"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,12 @@ enum BrandStatus {
   INACTIVE // Owner intentionally deactivated the brand (soft-delete)
 }
 
+enum ProductStatus {
+  DRAFT
+  ARCHIVED
+  PUBLISHED
+}
+
 enum PaymentMethod {
   CREDIT_CARD
   DEBIT_CARD
@@ -146,6 +152,7 @@ model Brand {
   crn             String?
   taxId           String?
   paymentMethod   PaymentMethod?
+  Products        Product[]
   createdAt       DateTime       @default(now())
   updatedAt       DateTime       @updatedAt
 
@@ -240,4 +247,148 @@ model PrivateMessageVisibility {
   @@unique([messageId, accountId])
   @@index([accountId])
   @@index([messageId])
+}
+
+model Product {
+  id          String        @id @default(uuid())
+  brandId     String
+  category    Category
+  title       String
+  slug        String
+  description String?
+  attributes  Json?
+  status      ProductStatus @default(DRAFT)
+  material    String? // NEW: material (e.g., Cotton, Leather)
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  brand    Brand           @relation(fields: [brandId], references: [id])
+  images   ProductImage[]
+  variants Variant[]
+  options  ProductOption[]
+  tags     ProductTag[]
+
+  @@unique([brandId, slug])
+  @@index([category, status, createdAt(sort: Desc)])
+  @@index([material])
+}
+
+model ProductImage {
+  id        String   @id @default(uuid())
+  productId String
+  url       String
+  altText   String?
+  meta      Json?
+  sortOrder Int      @default(0)
+  createdAt DateTime @default(now())
+
+  product Product @relation(fields: [productId], references: [id])
+
+  @@unique([productId, sortOrder])
+  @@index([productId])
+}
+
+model ProductOption {
+  id        String  @id @default(uuid())
+  productId String
+  name      String // machine name, e.g., "color", "size"
+  label     String? // display label, e.g., "Color", "Size"
+  sortOrder Int     @default(0)
+
+  product       Product              @relation(fields: [productId], references: [id])
+  values        ProductOptionValue[]
+  VariantOption VariantOption[]
+
+  @@unique([productId, name])
+  @@index([productId, sortOrder])
+}
+
+model ProductOptionValue {
+  id              String  @id @default(uuid())
+  productOptionId String
+  value           String // machine value, e.g., "red", "xl"
+  label           String? // display value, e.g., "Red", "XL"
+  colorHex        String? // optional (#RRGGBB)
+  sortOrder       Int     @default(0)
+
+  option       ProductOption   @relation(fields: [productOptionId], references: [id])
+  variantLinks VariantOption[]
+
+  @@unique([productOptionId, value])
+  @@index([productOptionId, sortOrder])
+}
+
+model VariantOption {
+  id                   String @id @default(uuid())
+  variantId            String
+  productOptionId      String
+  productOptionValueId String
+
+  variant Variant            @relation(fields: [variantId], references: [id])
+  option  ProductOption      @relation(fields: [productOptionId], references: [id])
+  value   ProductOptionValue @relation(fields: [productOptionValueId], references: [id])
+
+  // Ensure a variant has at most one selection per option (e.g., only one size)
+  @@unique([variantId, productOptionId])
+  @@index([productOptionValueId])
+}
+
+model Variant {
+  id         String   @id @default(uuid())
+  productId  String
+  sku        String
+  price      Decimal  @db.Decimal(12, 2)
+  currency   String   @db.VarChar(3)
+  stock      Int      @default(0)
+  weight     Decimal? @db.Decimal(10, 3)
+  dimensions Json?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  product Product         @relation(fields: [productId], references: [id])
+  images  VariantImage[]
+  options VariantOption[]
+
+  @@unique([productId, sku])
+  @@index([productId])
+}
+
+model VariantImage {
+  id        String   @id @default(uuid())
+  variantId String
+  url       String
+  altText   String?
+  sortOrder Int      @default(0)
+  createdAt DateTime @default(now())
+
+  variant Variant @relation(fields: [variantId], references: [id])
+
+  @@unique([variantId, sortOrder])
+  @@index([variantId])
+}
+
+model Tag {
+  id        String   @id @default(uuid())
+  name      String
+  slug      String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  products ProductTag[]
+
+  @@index([name])
+}
+
+// Explicit M2M join to allow future metadata
+model ProductTag {
+  productId String
+  tagId     String
+  pinned    Boolean  @default(false)
+  addedAt   DateTime @default(now())
+
+  product Product @relation(fields: [productId], references: [id])
+  tag     Tag     @relation(fields: [tagId], references: [id])
+
+  @@id([productId, tagId])
+  @@index([tagId, productId])
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import authRouter from "./modules/auth/auth.routes";
 import userRouter from "./modules/user/user.routes";
 import brandRouter from "./modules/brand/brand.routes";
 import chatRouter from "./modules/chat/chat.routes";
+import productRouter from "./modules/product/product.routes";
 import { notFound } from "./middlewares/notFound.middleware";
 import { errorHandler } from "./middlewares/error.middleware";
 import { cleanResponseMiddleware } from "./middlewares/cleanResponse.middleware";
@@ -22,6 +23,7 @@ app.use("/api/v1/auth", authRouter);
 app.use("/api/v1/users", userRouter);
 app.use("/api/v1/brands", brandRouter);
 app.use("/api/v1/chats", chatRouter);
+app.use("/api/v1/products", productRouter);
 
 // 404 catcher — should come after routes
 app.use(notFound);

--- a/src/modules/product/product.controller.ts
+++ b/src/modules/product/product.controller.ts
@@ -1,0 +1,329 @@
+import { Request, Response, NextFunction } from "express";
+import { HttpStatus } from "../../enums/httpStatus.enum";
+import APIError from "../../utils/APIError";
+import { ProductService } from "./product.service";
+import { toPrismaJson } from "./product.validation";
+import { sendResponse } from "../../utils/response";
+
+/** GET /products */
+export async function getAllProducts(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const data = await ProductService.getAllProducts(req.query as any);
+
+  sendResponse(res, {
+    statusCode: HttpStatus.OK,
+    data,
+  });
+}
+
+/** GET /products/:productId */
+export async function getProductById(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const { productId } = req.params as { productId: string };
+  const data = await ProductService.getProductById(productId);
+  if (!data)
+    return sendResponse(res, {
+      statusCode: HttpStatus.NotFound,
+      message: "Product Not Found.",
+    });
+
+  sendResponse(res, {
+    statusCode: HttpStatus.OK,
+    data,
+  });
+}
+
+/** GET /products/slug/:slug */
+export async function getProductBySlug(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const { slug } = req.params as { slug: string };
+  const data = await ProductService.getProductBySlug(slug);
+
+  if (!data)
+    return sendResponse(res, {
+      statusCode: HttpStatus.NotFound,
+      message: "Product Not Found.",
+    });
+
+  sendResponse(res, {
+    statusCode: HttpStatus.OK,
+    data,
+  });
+}
+
+/** POST /products (auth) */
+export async function createProduct(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const actorAccountId = (req as any)?.account?.id as string | undefined;
+  if (!actorAccountId)
+    throw new APIError("Unauthorized", HttpStatus.Unauthorized);
+
+  const body = req.body as any;
+  const payload = { ...body, attributes: toPrismaJson(body.attributes) };
+  const created = await ProductService.createProduct(payload, actorAccountId);
+
+  sendResponse(res, {
+    statusCode: HttpStatus.OK,
+    data: created,
+  });
+}
+
+/** PATCH /products/:productId (auth) */
+export async function updateProduct(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const actorAccountId = (req as any)?.account?.id as string | undefined;
+  if (!actorAccountId)
+    throw new APIError("Unauthorized", HttpStatus.Unauthorized);
+
+  const { productId } = req.params as { productId: string };
+  const body = req.body as any; // validated
+  const payload = { ...body, attributes: toPrismaJson(body.attributes) };
+  const updated = await ProductService.updateProduct(
+    productId,
+    payload,
+    actorAccountId
+  );
+
+  sendResponse(res, {
+    statusCode: HttpStatus.OK,
+    data: updated,
+  });
+}
+
+/** DELETE /products/:productId (auth) */
+export async function deleteProduct(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const actorAccountId = (req as any)?.account?.id as string | undefined;
+  if (!actorAccountId)
+    throw new APIError("Unauthorized", HttpStatus.Unauthorized);
+
+  const { productId } = req.params as { productId: string };
+  await ProductService.deleteProductById(productId, actorAccountId);
+
+  sendResponse(res, {
+    statusCode: HttpStatus.NoContent,
+  });
+}
+
+/** POST /products/:productId/publish (auth) */
+export async function publishProduct(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const actorAccountId = (req as any)?.account?.id as string | undefined;
+  if (!actorAccountId)
+    throw new APIError("Unauthorized", HttpStatus.Unauthorized);
+
+  const { productId } = req.params as { productId: string };
+  const out = await ProductService.publish(productId, actorAccountId);
+
+  sendResponse(res, {
+    statusCode: HttpStatus.OK,
+    data: out,
+  });
+}
+
+/** POST /products/:productId/unpublish (auth) */
+export async function unpublishProduct(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const actorAccountId = (req as any)?.account?.id as string | undefined;
+  if (!actorAccountId)
+    throw new APIError("Unauthorized", HttpStatus.Unauthorized);
+
+  const { productId } = req.params as { productId: string };
+  const out = await ProductService.unpublish(productId, actorAccountId);
+
+  sendResponse(res, {
+    statusCode: HttpStatus.OK,
+    data: out,
+  });
+}
+
+/** POST /products/:productId/archive (auth) */
+export async function archiveProduct(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const actorAccountId = (req as any)?.account?.id as string | undefined;
+  if (!actorAccountId)
+    throw new APIError("Unauthorized", HttpStatus.Unauthorized);
+
+  const { productId } = req.params as { productId: string };
+  const out = await ProductService.archive(productId, actorAccountId);
+
+  sendResponse(res, {
+    statusCode: HttpStatus.OK,
+    data: out,
+  });
+}
+
+/* ---------------- Product Tags sub-controllers ---------------- */
+
+// import {
+//     listTagsForProduct,
+//     attachTagToProduct,
+//     attachTagsToProductBulk,
+//     detachTagFromProduct,
+//     togglePinned,
+//     listAllTags,
+//     listProductsByTagSlug,
+//   } from "./tag.services";
+
+//   /** GET /products/:productId/tags */
+//   export async function listProductTagsCtrl(
+//     req: Request,
+//     res: Response,
+//     next: NextFunction
+//   ) {
+//     try {
+//       const { productId } = req.params as { productId: string };
+//       const items = await listTagsForProduct(productId);
+//       res.status(HttpStatus.OK).json({ items });
+//     } catch (err) {
+//       next(err);
+//     }
+//   }
+
+//   /** POST /products/:productId/tags (auth) */
+//   export async function attachTagCtrl(
+//     req: Request,
+//     res: Response,
+//     next: NextFunction
+//   ) {
+//     try {
+//       const actorAccountId = (req as any)?.account?.id as string | undefined;
+//       if (!actorAccountId)
+//         throw new APIError("Unauthorized", HttpStatus.Unauthorized);
+
+//       const { productId } = req.params as { productId: string };
+//       const { nameOrSlug, pinned } = req.body as {
+//         nameOrSlug: string;
+//         pinned?: boolean;
+//       };
+//       // ownership guard is inside ProductService; for tags, we can reuse it if preferred
+//       await ProductService["updateProduct"]; // no-op import retention (tree-shaking caveat)
+//       const out = await attachTagToProduct(productId, nameOrSlug, { pinned });
+//       res.status(HttpStatus.Created).json(out);
+//     } catch (err) {
+//       next(err);
+//     }
+//   }
+
+//   /** POST /products/:productId/tags/bulk (auth) */
+//   export async function attachTagsBulkCtrl(
+//     req: Request,
+//     res: Response,
+//     next: NextFunction
+//   ) {
+//     try {
+//       const actorAccountId = (req as any)?.account?.id as string | undefined;
+//       if (!actorAccountId)
+//         throw new APIError("Unauthorized", HttpStatus.Unauthorized);
+
+//       const { productId } = req.params as { productId: string };
+//       const { tags } = req.body as {
+//         tags: { nameOrSlug: string; pinned?: boolean }[];
+//       };
+//       const out = await attachTagsToProductBulk(productId, tags);
+//       res.status(HttpStatus.OK).json({ items: out });
+//     } catch (err) {
+//       next(err);
+//     }
+//   }
+
+//   /** DELETE /products/:productId/tags/:tagSlug (auth) */
+//   export async function detachTagCtrl(
+//     req: Request,
+//     res: Response,
+//     next: NextFunction
+//   ) {
+//     try {
+//       const actorAccountId = (req as any)?.account?.id as string | undefined;
+//       if (!actorAccountId)
+//         throw new APIError("Unauthorized", HttpStatus.Unauthorized);
+
+//       const { productId, tagSlug } = req.params as {
+//         productId: string;
+//         tagSlug: string;
+//       };
+//       const out = await detachTagFromProduct(productId, tagSlug);
+//       res.status(HttpStatus.OK).json(out);
+//     } catch (err) {
+//       next(err);
+//     }
+//   }
+
+//   /** POST /products/:productId/tags/:tagSlug/pinned (auth) */
+//   export async function togglePinnedCtrl(
+//     req: Request,
+//     res: Response,
+//     next: NextFunction
+//   ) {
+//     try {
+//       const actorAccountId = (req as any)?.account?.id as string | undefined;
+//       if (!actorAccountId)
+//         throw new APIError("Unauthorized", HttpStatus.Unauthorized);
+
+//       const { productId, tagSlug } = req.params as {
+//         productId: string;
+//         tagSlug: string;
+//       };
+//       const { pinned } = req.body as { pinned: boolean };
+//       const row = await togglePinned(productId, tagSlug, !!pinned);
+//       res.status(HttpStatus.OK).json(row);
+//     } catch (err) {
+//       next(err);
+//     }
+//   }
+
+//   /** GET /products/tags */
+//   export async function listAllTagsCtrl(
+//     _req: Request,
+//     res: Response,
+//     next: NextFunction
+//   ) {
+//     try {
+//       const data = await listAllTags();
+//       res.status(HttpStatus.OK).json(data);
+//     } catch (err) {
+//       next(err);
+//     }
+//   }
+
+//   /** GET /products/tags/:tagSlug/products */
+//   export async function listProductsByTagSlugCtrl(
+//     req: Request,
+//     res: Response,
+//     next: NextFunction
+//   ) {
+//     try {
+//       const { tagSlug } = req.params as { tagSlug: string };
+//       const data = await listProductsByTagSlug(tagSlug, req.query as any);
+//       res.status(HttpStatus.OK).json(data);
+//     } catch (err) {
+//       next(err);
+//     }
+//   }

--- a/src/modules/product/product.interface.ts
+++ b/src/modules/product/product.interface.ts
@@ -1,0 +1,80 @@
+// import { promises } from "dns";
+import type { Prisma, Category, ProductStatus } from "../../generated/prisma";
+// import type { Prisma } from "@prisma/client";
+
+export interface PageOptions {
+  page?: number; // 1- pased
+  limit?: number; // default 20, max 100
+}
+
+export interface ListProductsQuery extends PageOptions {
+  q?: string;
+  brandId?: string;
+  category?: Category;
+  status?: ProductStatus;
+  material?: string;
+  minPrice?: number;
+  maxPrice?: number;
+}
+
+export interface ImageInput {
+  url: string;
+  altText?: string | null;
+  sortOrder?: number;
+}
+
+export interface CreateProduct {
+  brandId: string;
+  category: Category;
+  title: string;
+  slug?: string;
+  description?: string | null;
+  attributes?: Prisma.InputJsonValue | null;
+  status?: ProductStatus;
+  material?: string | null;
+  images?: ImageInput[];
+}
+
+export interface UpdateProduct {
+  category?: Category;
+  title?: string;
+  slug?: string;
+  description?: string | null;
+  attributes?: Prisma.InputJsonValue | null;
+  status: ProductStatus;
+  material?: string | null;
+  images?: ImageInput[];
+}
+
+export interface ProductServices {
+  getAllProducts(
+    query: ListProductsQuery
+  ): Promise<{ items: any[]; page: number; limit: number; total: number }>;
+
+  getProductById(id: string): Promise<any | null>;
+  getProductBySlug(slug: string): Promise<any | null>;
+
+  createProduct(payload: CreateProduct, actorAccountId: string): Promise<any>;
+  updateProduct(
+    productId: string,
+    dto: UpdateProduct,
+    actorAccountId: string
+  ): Promise<any>;
+  deleteProductById(
+    productId: string,
+    actorAccountId: string
+  ): Promise<{ id: string }>;
+
+  publish(
+    productId: string,
+    actorAccountId: string
+  ): Promise<{ id: string; status: ProductStatus }>;
+  unpublish(
+    productId: string,
+    actorAccountId: string
+  ): Promise<{ id: string; status: ProductStatus }>;
+  archive(
+    productId: string,
+    actorAccountId: string
+  ): Promise<{ id: string; status: ProductStatus }>;
+}

--- a/src/modules/product/product.routes.ts
+++ b/src/modules/product/product.routes.ts
@@ -1,0 +1,71 @@
+import { Router } from "express";
+import { authenticate } from "../../middlewares/authenticate.middleware";
+import { validate } from "../../middlewares/validation.middleware";
+
+import {
+  createProductSchema,
+  updateProductSchema,
+  listProductsQuerySchema,
+  productIdParamSchema,
+  productSlugParamSchema,
+} from "./product.validation";
+
+import {
+  getAllProducts,
+  getProductById,
+  getProductBySlug,
+  createProduct,
+  updateProduct,
+  deleteProduct,
+  publishProduct,
+  unpublishProduct,
+  archiveProduct,
+} from "./product.controller";
+
+const router = Router();
+
+/** Public browse */
+router.get("/", validate(listProductsQuerySchema), getAllProducts);
+router.get("/slug/:slug", validate(productSlugParamSchema), getProductBySlug);
+router.get("/:productId", validate(productIdParamSchema), getProductById);
+
+/** Product tag browsing (public) */
+// router.get("/tags", validate(tagsBrowseQuerySchema), listAllTagsCtrl);
+// router.get("/tags/:tagSlug/products", listProductsByTagSlugCtrl);
+
+/** Auth required for writes (brand ownership enforced in service) */
+router.post("/", authenticate, validate(createProductSchema), createProduct);
+router.patch(
+  "/:productId",
+  authenticate,
+  validate(productIdParamSchema),
+  validate(updateProductSchema),
+  updateProduct
+);
+router.delete(
+  "/:productId",
+  authenticate,
+  validate(productIdParamSchema),
+  deleteProduct
+);
+
+router.post(
+  "/:productId/publish",
+  authenticate,
+  validate(productIdParamSchema),
+  publishProduct
+);
+router.post(
+  "/:productId/unpublish",
+  authenticate,
+  validate(productIdParamSchema),
+  unpublishProduct
+);
+router.post(
+  "/:productId/archive",
+  authenticate,
+  validate(productIdParamSchema),
+  archiveProduct
+);
+
+export default router;

--- a/src/modules/product/product.validation.ts
+++ b/src/modules/product/product.validation.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+import { Category, ProductStatus, Prisma } from "../../generated/prisma";
+
+export const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const ImageInput = z.object({
+  url: z.string().url(),
+  altText: z.string().max(160).optional().nullable(),
+  sortOrder: z.number().int().min(0).optional(),
+});
+
+/* ---------------- Body Schemas ---------------- */
+export const createProductSchema = z.object({
+  body: z.object({
+    brandId: z.string().uuid(),
+    category: z.enum(Category),
+    title: z.string().min(3).max(140),
+    slug: z.string().regex(slugRegex).optional(),
+    description: z.string().max(4000).optional().nullable(),
+    attributes: z.any().optional().nullable(),
+    material: z.string().max(120).optional().nullable(),
+    images: z.array(ImageInput).default([]),
+    status: z.enum(ProductStatus).optional(),
+  }),
+});
+
+export const updateProductSchema = z.object({
+  body: z.object({
+    category: z.enum(Category).optional(),
+    title: z.string().min(3).max(140).optional(),
+    slug: z.string().regex(slugRegex).optional(),
+    description: z.string().max(4000).optional().nullable(),
+    attributes: z.any().optional().nullable(),
+    material: z.string().max(120).optional().nullable(),
+    status: z.enum(ProductStatus).optional(),
+    images: z.array(ImageInput).optional(),
+  }),
+});
+
+/* ---------------- Query Schemas ---------------- */
+export const listProductsQuerySchema = z.object({
+  query: z.object({
+    q: z.string().max(120).optional(),
+    brandId: z.string().uuid().optional(),
+    category: z.enum(Category).optional(),
+    status: z.enum(ProductStatus).optional(),
+    material: z.string().max(120).optional(),
+    minPrice: z.coerce.number().nonnegative().optional(),
+    maxPrice: z.coerce.number().nonnegative().optional(),
+    page: z.coerce.number().int().positive().optional(),
+    limit: z.coerce.number().int().positive().max(100).optional(),
+  }),
+});
+
+export const tagsBrowseQuerySchema = z.object({
+  query: z.object({
+    page: z.coerce.number().int().positive().optional(),
+    limit: z.coerce.number().int().positive().max(100).optional(),
+  }),
+});
+
+/* ---------------- Param Schemas ---------------- */
+export const productIdParamSchema = z.object({
+  params: z.object({ productId: z.string().uuid() }),
+});
+
+export const productSlugParamSchema = z.object({
+  params: z.object({ slug: z.string().regex(slugRegex) }),
+});
+
+export const productIdTagSlugParamsSchema = z.object({
+  params: z.object({
+    productId: z.string().uuid(),
+    tagSlug: z.string().min(1),
+  }),
+});
+
+/* ---------------- Tag Body Schemas ---------------- */
+export const attachTagBodySchema = z.object({
+  body: z.object({
+    nameOrSlug: z.string().min(1),
+    pinned: z.boolean().optional(),
+  }),
+});
+
+export const attachTagsBulkBodySchema = z.object({
+  body: z.object({
+    tags: z.array(
+      z.object({
+        nameOrSlug: z.string().min(1),
+        pinned: z.boolean().optional(),
+      })
+    ),
+  }),
+});
+
+export const togglePinnedBodySchema = z.object({
+  body: z.object({ pinned: z.boolean() }),
+});
+
+/* ---------------- Util ---------------- */
+export const toPrismaJson = (v: unknown): Prisma.InputJsonValue | undefined =>
+  v === undefined ? undefined : (v as Prisma.InputJsonValue);


### PR DESCRIPTION
This PR lays the foundation for product catalog management in the BuyBuddy app.
## Implemented Features
### Prisma Models

- Product with fields: title, slug, description, material, attributes (flexible JSON), status.
- Relations: Brand, ProductImage, Variant, ProductOption, ProductTag.
- ProductImage model for product galleries (with sort order).
- Variant / VariantImage / VariantOption / ProductOption / ProductOptionValue for configurable products (size, color, etc.).
- Tag / ProductTag explicit M2M with metadata (pinned, addedAt).

### Services (product.service.ts)

- CRUD operations: list, get by ID, get by slug, create, update, delete.
- Publishing workflow: publish, unpublish, archive.
- Ownership guards: enforce brand/product ↔ accountId authorization.
- Pagination & filters: query by category, status, material, full-text search (q), price ranges (via variants.some).
- Safe selects: card view vs. detail view for optimized responses.

### Controllers (product.controller.ts)
Implemented controllers for all CRUD + workflow endpoints.
### Validation (product.validation.ts)
Zod schemas for:

- Product creation & update body.
- Product listing queries (search, pagination, filters).
- Params (productId, slug, tagSlug).
- Tag operations (attach single, bulk, pinned toggle).
- Structured as { body, query, params } → works with generic validate() middleware.